### PR TITLE
info.rkt: fix license id type

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -6,4 +6,4 @@
 (define pkg-desc "colorize your console")
 (define version "0.1")
 (define pkg-authors '(yanyingwang)
-(define license '(Apache-2.0))
+(define license 'Apache-2.0)


### PR DESCRIPTION
https://docs.racket-lang.org/pkg/metadata.html#%28tech._license._s._expression%29

Bug: https://github.com/yanyingwang/colorize/issues/3
Signed-off-by: Maciej Barć <xgqt@gentoo.org>