### PR TITLE
info.rkt: fix missing ")" & use proper case syntax 

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -5,5 +5,5 @@
 (define scribblings '(("scribblings/colorize.scrbl" ())))
 (define pkg-desc "colorize your console")
 (define version "0.1")
-(define pkg-authors '(yanyingwang)
+(define pkg-authors '(yanyingwang))
 (define license 'Apache-2.0)

--- a/main.rkt
+++ b/main.rkt
@@ -40,9 +40,9 @@
         [styles (dict-keys (colorize/codes 'style))])
     (case type
       [(color background) colors]
-      ['style styles]
-      ['all `((color ,@colors)
-              (style ,@styles))])))
+      [(style) styles]
+      [(all) `((color ,@colors)
+               (style ,@styles))])))
 
 (define (colorize/codes [type 'all])
   (let* ([style-codes '((default . "0")            ; Turn off all attributes
@@ -77,9 +77,9 @@
                                 `(,(car l) . ,(number->string (+ (cdr l) 40))))
                               color-codes)])
     (case type
-      ['fg-color fg-color-codes]
-      ['bg-color bg-color-codes]
-      ['style style-codes]
-      ['all `((fg-color ,@fg-color-codes)
-              (bg-color ,@bg-color-codes)
-              (style ,@style-codes))])))
+      [(fg-color) fg-color-codes]
+      [(bg-color) bg-color-codes]
+      [(style) style-codes]
+      [(all) `((fg-color ,@fg-color-codes)
+               (bg-color ,@bg-color-codes)
+               (style ,@style-codes))])))


### PR DESCRIPTION
Signed-off-by: Maciej Barć <xgqt@gentoo.org>

![image](https://user-images.githubusercontent.com/47485207/195723761-de7d8f0d-3b5b-41d4-89f6-23806eb90496.png)

There was a misstype in "Update info.rkt" commit.